### PR TITLE
Evaluates eventrouter for Yolean/kubernetes-kafka

### DIFF
--- a/yaml/eventrouter.yaml
+++ b/yaml/eventrouter.yaml
@@ -44,7 +44,11 @@ apiVersion: v1
 data:
   config.json: |- 
     {
-      "sink": "glog"
+      "sink": "kafka",
+      "kafkaBrokers": "bootstrap.kafka:9092",
+      "kafkaTopic": "ops.kube-events.stream.json",
+      "kafkaAsync": false,
+      "kafkaRetryMax": 5
     }
 kind: ConfigMap
 metadata:
@@ -71,7 +75,7 @@ spec:
     spec:
       containers:
         - name: kube-eventrouter
-          image: gcr.io/heptio-images/eventrouter:latest
+          image: gcr.io/heptio-images/eventrouter@sha256:30e36ce7bad4a7c539e0a0cb1833d309089919fb0ef0c165ee28aabe97740d02
           imagePullPolicy: IfNotPresent
           volumeMounts:
           - name: config-volume


### PR DESCRIPTION
See for example https://github.com/Yolean/kubernetes-kafka/issues/109

Note that the topic name is different.

I guess this solution will - like the old curl based one - drop messages if the pod gets rescheduled in an uncontrolled way, i.e. not a rolling upgrade. Still a lot better than with curl because it doesn't restart.